### PR TITLE
strings.Fields() also handles accidental double spaces

### DIFF
--- a/plugins/command/command.go
+++ b/plugins/command/command.go
@@ -70,7 +70,7 @@ func handleMessage(e gofra.Event) *gofra.Reply {
 		return nil
 	}
 
-	command = strings.Split(e.MB.Body, " ")[0][1:]
+	command = strings.Fields(e.MB.Body)[0][1:]
 	eventName := "command/" + command
 
 	event := gofra.Event{

--- a/plugins/cryptoasset_info/cryptoasset_info.go
+++ b/plugins/cryptoasset_info/cryptoasset_info.go
@@ -46,7 +46,7 @@ func handleAssetInfo(e gofra.Event) *gofra.Reply {
 	var asset string
 
 	var r *gofra.Reply
-	args := strings.Split(e.MB.Body, " ")[1:]
+	args := strings.Fields(e.MB.Body)[1:]
 	argLength := len(args)
 
 	switch {

--- a/plugins/dice/dice.go
+++ b/plugins/dice/dice.go
@@ -75,7 +75,7 @@ func handleCommand(e gofra.Event) *gofra.Reply {
 }
 
 func parseArgs(argLine string) []throw {
-	args := strings.Split(argLine, " ")[1:]
+	args := strings.Fields(argLine)[1:]
 
 	if len(args) == 0 {
 		return []throw{{quantity: defaultDiceQuantity, faces: defaultDiceFaces}}

--- a/plugins/pairs_price/pairs_price.go
+++ b/plugins/pairs_price/pairs_price.go
@@ -48,7 +48,7 @@ func handlePrice(e gofra.Event) *gofra.Reply {
 	var exchange, pair string
 
 	var r *gofra.Reply
-	args := strings.Split(e.MB.Body, " ")[1:]
+	args := strings.Fields(e.MB.Body)[1:]
 	argLength := len(args)
 
 	switch {

--- a/plugins/pick/pick.go
+++ b/plugins/pick/pick.go
@@ -39,7 +39,7 @@ func (p plugin) Init(c gofra.Config, gofra *gofra.Gofra) {
 }
 
 func parseArgs(argLine string) (int, []string) {
-	args := strings.Split(argLine, " ")
+	args := strings.Fields(argLine)
 	command := args[0]
 	optLine := ""
 

--- a/plugins/reminder/reminder.go
+++ b/plugins/reminder/reminder.go
@@ -91,7 +91,7 @@ func (p plugin) Run() {
 
 func handleReminder(e gofra.Event) *gofra.Reply {
 	msg := e.MB
-	args := strings.Split(msg.Body, " ")[1:]
+	args := strings.Fields(msg.Body)[1:]
 
 	if len(args) < 1 || (len(args) > 0 && args[0] == "") {
 		if err := g.SendStanza(e.MB.Reply("Need a message to remind")); err != nil {

--- a/plugins/session_tracker/session_tracker.go
+++ b/plugins/session_tracker/session_tracker.go
@@ -36,7 +36,7 @@ func (p plugin) Init(c gofra.Config, gofra *gofra.Gofra) {
 }
 
 func handleSession(e gofra.Event) *gofra.Reply {
-	args := strings.Split(e.MB.Body, " ")[1:]
+	args := strings.Fields(e.MB.Body)[1:]
 
 	s, exists := sessions[e.MB.From.String()]
 	if len(args) < 1 {

--- a/plugins/trivia/trivia.go
+++ b/plugins/trivia/trivia.go
@@ -60,7 +60,7 @@ func StartNewSession(req roundRequest) error {
 }
 
 func handleCommand(e gofra.Event) *gofra.Reply {
-	args := strings.Split(e.MB.Body, " ")[1:]
+	args := strings.Fields(e.MB.Body)[1:]
 	r := e.MB.Reply
 
 	if len(args) == 0 {


### PR DESCRIPTION
and many other special space characters.

So there's no reason to be using bare Split for general parsing cases.