### PR TITLE
fix module name to make project importable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gofra
+module github.com/XaviFP/gofra
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var config gofra.Config

--- a/plugins/command/command.go
+++ b/plugins/command/command.go
@@ -7,7 +7,7 @@ package main
 import (
 	"strings"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/cryptoasset_info/cryptoasset_info.go
+++ b/plugins/cryptoasset_info/cryptoasset_info.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/dice/dice.go
+++ b/plugins/dice/dice.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/example/example.go
+++ b/plugins/example/example.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/muc/muc.go
+++ b/plugins/muc/muc.go
@@ -11,7 +11,7 @@ import (
 	"mellium.im/xmpp/muc"
 	"mellium.im/xmpp/stanza"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/pairs_price/pairs_price.go
+++ b/plugins/pairs_price/pairs_price.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/pick/pick.go
+++ b/plugins/pick/pick.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/reminder/reminder.go
+++ b/plugins/reminder/reminder.go
@@ -16,7 +16,7 @@ import (
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/stanza"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/session_tracker/session_tracker.go
+++ b/plugins/session_tracker/session_tracker.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/plugins/trivia/trivia.go
+++ b/plugins/trivia/trivia.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/juju/errors"
 
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/test_plugins/naughty/naughty.go
+++ b/test_plugins/naughty/naughty.go
@@ -5,7 +5,7 @@ naughty is a test gofra plugin that tries to crash gofra through panicking handl
 package main
 
 import (
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin

--- a/test_plugins/normie/normie.go
+++ b/test_plugins/normie/normie.go
@@ -5,7 +5,7 @@ normie is a gofra plugin.
 package main
 
 import (
-	"gofra/gofra"
+	"github.com/XaviFP/gofra/gofra"
 )
 
 var Plugin plugin


### PR DESCRIPTION
The previous module name is invalid, causing tools that are stricter than the compiler to fail to when reading this module. Changing it to the full import path allows these tools to work (eg. pkg.go.dev can now parse this package and show it in search results on go.dev).

This also makes the module installable with `go install`